### PR TITLE
Add JBrowse 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to the docker-bio-linux8-resolwe project will be documented
 in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+
+- JBrowse 1.12.0.
+
 ## 0.1.0 - 2016-02-04
 
 - Initial release.

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,28 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     # XXX: Remove this after updating resolwe-runtime-utils
     echo "[[ -f ~/.bash_profile ]] && source ~/.bash_profile" >> ~/.bashrc && \
 
+    echo "Installing JBrowse..." && \
+    JBROWSE_VERSION=1.12.0 && \
+    JBROWSE_SHA1SUM=c74adeb9840ae5c9348e59a9054fa93cf68d0402 && \
+    wget -q https://jbrowse.org/releases/JBrowse-$JBROWSE_VERSION.zip -O jbrowse.zip && \
+    echo "$JBROWSE_SHA1SUM *jbrowse.zip" | sha1sum -c - && \
+    unzip -q jbrowse.zip && \
+    rm jbrowse.zip && \
+    cd JBrowse-$JBROWSE_VERSION && \
+    # patch setup.sh script to prevent formatting of example data and building
+    # support for legacy tools
+    sed -i '/Formatting Volvox example data .../,$d' setup.sh && \
+    ./setup.sh && \
+    # remove all files and directories except those we explicitly want to keep
+    find . -depth -not \( \
+        -path './bin*' -o \
+        -path './src/perl5*' -o \
+        -path './extlib/lib/perl5*' \
+        -o \( -type d -not -empty \) \
+    \) -delete && \
+    echo "PATH=\$PATH:~/JBrowse-$JBROWSE_VERSION/bin" >> ~/.bash_profile && \
+    cd .. && \
+
     echo "Preparing directories..." && \
     mkdir upload && \
     mkdir data && \


### PR DESCRIPTION
~~TODO~~:
- [x] Add changelog entry

Some benchmarks:

```
[tadej@tlinux64 docker-bio-linux8-resolwe]$ docker images
REPOSITORY                   TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
resolwe/bio-linux8-resolwe   bad                 bb5a77605f77        17 hours ago        4.281 GB
resolwe/bio-linux8-resolwe   good                b7986f0ee744        17 hours ago        4.243 GB
resolwe/bio-linux8-resolwe   previous            dab0872012f9        3 days ago          4.226 GB
```

Docker image `resolwe/bio-linux8-resolwe:good` size increase: **17 MB**.
Docker image `resolwe/bio-linux8-resolwe:bad`  size increase: **55 MB**.

The `resolwe/bio-linux8-resolwe:good` image represents a stripped-down install of JBrowse without example data and files supporting legacy tools which is implemented in this pull request.
The `resolwe/bio-linux8-resolwe:bad` image represents a standard install of JBrowse.
